### PR TITLE
fix tests, fix compatibility with celery 3.1.x

### DIFF
--- a/celery_redis_sentinel/register.py
+++ b/celery_redis_sentinel/register.py
@@ -7,7 +7,7 @@ from kombu.transport import TRANSPORT_ALIASES
 from .backend import RedisSentinelBackend
 from .transport import SentinelTransport
 
-if celery.VERSION.major < 4:
+if celery.VERSION[0] < 4:
     from celery.backends import BACKEND_ALIASES
 else:
     from celery.app.backends import BACKEND_ALIASES

--- a/celery_redis_sentinel/transport.py
+++ b/celery_redis_sentinel/transport.py
@@ -46,6 +46,7 @@ class SentinelChannel(Channel):
         CelerySentinelConnectionPool
             Connection pool instance connected to redis sentinel
         """
+
         params = self._connparams()
         params.update({
             'sentinels': self.sentinels,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -33,6 +33,7 @@ class TestRedisSentinelBackend(object):
                        ('192.168.1.3', 26379)],
             service_name='master',
             socket_timeout=1,
+            socket_connect_timeout=mock.ANY,
             host=mock.ANY,
             max_connections=mock.ANY,
             password=mock.ANY,

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -2,10 +2,15 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import mock
-from celery.backends import BACKEND_ALIASES
 from kombu.transport import TRANSPORT_ALIASES
+import celery
 
 from celery_redis_sentinel.register import get_class_path, register
+
+if celery.VERSION[0] < 4:
+    from celery.backends import BACKEND_ALIASES
+else:
+    from celery.app.backends import BACKEND_ALIASES
 
 
 class Foo(object):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -41,6 +41,7 @@ class TestSentinelChannel(object):
             password=mock.ANY,
             port=mock.ANY,
             connection_pool_class=CelerySentinelConnectionPool,
+            connection_class=mock.ANY,
             redis_class=channel.Client,
             db=0,
             sentinels=[('192.168.1.1', 26379),


### PR DESCRIPTION
Sorry, I did not check tests in previous PR. Now they [works](https://travis-ci.org/AyumuKasuga/celery-redis-sentinel/builds/211863320) in Celery 4 too.
Also unexpectedly in celery 3.1.x `celery.VERSION`  just a tuple.