### PR TITLE
use StrictRedis client

### DIFF
--- a/celery_redis_sentinel/backend.py
+++ b/celery_redis_sentinel/backend.py
@@ -3,9 +3,17 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from celery.backends.redis import RedisBackend
 from kombu.utils import cached_property
-from redis import StrictRedis
+import celery
 
 from .redis_sentinel import EnsuredRedisMixin, get_redis_via_sentinel
+
+try:
+    if celery.VERSION.major >= 4:
+        from redis import StrictRedis as Redis
+    else:
+        from redis import Redis
+except AttributeError:
+    from redis import Redis
 
 
 class RedisSentinelBackend(RedisBackend):
@@ -57,6 +65,6 @@ class RedisSentinelBackend(RedisBackend):
             'socket_timeout': self.socket_timeout,
         })
         return get_redis_via_sentinel(
-            redis_class=type(str('Redis'), (EnsuredRedisMixin, StrictRedis), {}),
+            redis_class=type(str('Redis'), (EnsuredRedisMixin, Redis), {}),
             **params
         )

--- a/celery_redis_sentinel/backend.py
+++ b/celery_redis_sentinel/backend.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from celery.backends.redis import RedisBackend
 from kombu.utils import cached_property
-from redis import Redis
+from redis import StrictRedis
 
 from .redis_sentinel import EnsuredRedisMixin, get_redis_via_sentinel
 
@@ -57,6 +57,6 @@ class RedisSentinelBackend(RedisBackend):
             'socket_timeout': self.socket_timeout,
         })
         return get_redis_via_sentinel(
-            redis_class=type(str('Redis'), (EnsuredRedisMixin, Redis), {}),
+            redis_class=type(str('Redis'), (EnsuredRedisMixin, StrictRedis), {}),
             **params
         )

--- a/celery_redis_sentinel/register.py
+++ b/celery_redis_sentinel/register.py
@@ -7,10 +7,13 @@ from kombu.transport import TRANSPORT_ALIASES
 from .backend import RedisSentinelBackend
 from .transport import SentinelTransport
 
-if celery.VERSION.major < 4:
+try:
+    if celery.VERSION.major >= 4:
+        from celery.app.backends import BACKEND_ALIASES
+    else:
+        from celery.backends import BACKEND_ALIASES
+except AttributeError:
     from celery.backends import BACKEND_ALIASES
-else:
-    from celery.app.backends import BACKEND_ALIASES
 
 
 def get_class_path(cls):

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -7,10 +7,13 @@ from kombu.transport import TRANSPORT_ALIASES
 
 from celery_redis_sentinel.register import get_class_path, register
 
-if celery.VERSION.major < 4:
+try:
+    if celery.VERSION.major >= 4:
+        from celery.app.backends import BACKEND_ALIASES
+    else:
+        from celery.backends import BACKEND_ALIASES
+except AttributeError:
     from celery.backends import BACKEND_ALIASES
-else:
-    from celery.app.backends import BACKEND_ALIASES
 
 
 class Foo(object):

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -2,10 +2,15 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import mock
-from celery.backends import BACKEND_ALIASES
+import celery
 from kombu.transport import TRANSPORT_ALIASES
 
 from celery_redis_sentinel.register import get_class_path, register
+
+if celery.VERSION.major < 4:
+    from celery.backends import BACKEND_ALIASES
+else:
+    from celery.app.backends import BACKEND_ALIASES
 
 
 class Foo(object):


### PR DESCRIPTION
The backend currently uses the "Redis" client, whereas celery redis backend assumes the "StrictRedis" client is used. This causes e.g. the SETEX command (used for expiring results) to fail.